### PR TITLE
Support multiple Distelli apps per wercker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 /.idea/
 *.iml
+.python-version

--- a/run.py
+++ b/run.py
@@ -8,7 +8,8 @@ import sys
 import yaml
 
 root = os.getenv("WERCKER_ROOT")
-release_filename = os.path.join(root, "usermind-release.txt")
+release_filename = os.getenv("WERCKER_DISTELLI_RELEASEFILENAME", "usermind-release.txt")
+release_filepath = os.path.join(root, release_filename)
 
 distelli = os.path.join(os.getenv("WERCKER_STEP_ROOT"), "DistelliCLI", "bin", "distelli")
 cache_dir = os.getenv("WERCKER_CACHE_DIR")

--- a/run.py
+++ b/run.py
@@ -194,14 +194,14 @@ def main():
     check_credentials()
 
     command = os.getenv("WERCKER_DISTELLI_COMMAND")
-    build_id = os.getenv("WERCKER_BUILD_ID")
+    build_url = os.getenv("WERCKER_BUILD_URL")
     deploy_url = os.getenv("WERCKER_DEPLOY_URL")
 
     if command is None:
         fail("command must be set")
 
     elif command == "push":
-        push(build_id)
+        push(build_url)
 
     elif command == "deploy":
         deploy(deploy_url)

--- a/run.py
+++ b/run.py
@@ -83,7 +83,7 @@ def locate_app_name():
     return app
 
 
-def locate_release_id(build_id):
+def locate_release_id(build_url):
     release_id = None
     app = locate_app_name()
 
@@ -91,7 +91,7 @@ def locate_release_id(build_id):
     reader = csv.reader(output.splitlines())
     for row in reader:
         description = row[3]
-        if description == "wercker:%s" % build_id:
+        if build_url in description:
             release_id = row[1]
             break
 
@@ -150,11 +150,11 @@ def invoke(cmd, capture=False):
     return output
 
 
-def push(build_id):
+def push(build_url):
     (dirname, basename) = check_manifest()
 
-    invoke("push -f %s -m wercker:%s" % (basename, build_id))
-    release_id = locate_release_id(build_id)
+    invoke("push -f %s -m %s" % (basename, build_url))
+    release_id = locate_release_id(build_url)
     save_release_id(release_id)
 
 
@@ -174,9 +174,8 @@ def deploy(deploy_id):
         fail("Either environment or host must be set")
 
     release_id = load_release_id()
-    (dirname, basename) = check_manifest()
 
-    args.extend(["-y", "-f", basename, "-r", release_id, "-m", os.getenv("WERCKER_DEPLOY_URL")])
+    args.extend(["-y", "-r", release_id, "-m", os.getenv("WERCKER_DEPLOY_URL")])
 
     cmd = "deploy %s" % " ".join(args)
     info(cmd)

--- a/run.py
+++ b/run.py
@@ -96,7 +96,7 @@ def locate_release_id(build_url):
             break
 
     if not release_id:
-        fail("Unable to locate release for build %s in app %s" % (build_id, app))
+        fail("Unable to locate release for build %s in app %s" % (build_url, app))
 
     return release_id
 

--- a/run.py
+++ b/run.py
@@ -158,7 +158,7 @@ def push(build_url):
     save_release_id(release_id)
 
 
-def deploy(deploy_id):
+def deploy(description):
     args = []
 
     environment = os.getenv("WERCKER_DISTELLI_ENVIRONMENT")
@@ -174,8 +174,9 @@ def deploy(deploy_id):
         fail("Either environment or host must be set")
 
     release_id = load_release_id()
+    (dirname, basename) = check_manifest()
 
-    args.extend(["-y", "-r", release_id, "-m", os.getenv("WERCKER_DEPLOY_URL")])
+    args.extend(["-y", "-f", basename, "-r", release_id, "-m", description])
 
     cmd = "deploy %s" % " ".join(args)
     info(cmd)
@@ -194,7 +195,7 @@ def main():
 
     command = os.getenv("WERCKER_DISTELLI_COMMAND")
     build_id = os.getenv("WERCKER_BUILD_ID")
-    deploy_id = os.getenv("WERCKER_DEPLOY_ID")
+    deploy_url = os.getenv("WERCKER_DEPLOY_URL")
 
     if command is None:
         fail("command must be set")
@@ -203,7 +204,7 @@ def main():
         push(build_id)
 
     elif command == "deploy":
-        deploy(deploy_id)
+        deploy(deploy_url)
 
     else:
         fail("unknown command: %s" % command)

--- a/run.py
+++ b/run.py
@@ -178,9 +178,12 @@ def deploy(deploy_id):
     args.extend(["-y", "-f", basename, "-r", release_id, "-m", os.getenv("WERCKER_DEPLOY_URL")])
 
     cmd = "deploy %s" % " ".join(args)
+    info(cmd)
     output = invoke(cmd, capture=True)
     if "Deployment Failed" in output:
         fail(output)
+    else:
+        info(output)
 
 
 def main():

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: distelli
-version: "0.1.3-alpha4"
+version: "0.1.3"
 description: Executes a distelli CLI command
 keywords:
   - distelli

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: distelli
-version: "0.1.3-alpha2"
+version: "0.1.3-alpha3"
 description: Executes a distelli CLI command
 keywords:
   - distelli

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: distelli
-version: "0.1.2"
+version: "0.1.3-alpha1"
 description: Executes a distelli CLI command
 keywords:
   - distelli

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: distelli
-version: "0.1.3-alpha1"
+version: "0.1.3-alpha2"
 description: Executes a distelli CLI command
 keywords:
   - distelli
@@ -22,4 +22,7 @@ properties:
     type: string
     required: false
     default: distelli-manifest.yml
-
+  releaseFilename:
+    type: string
+    required: false
+    default: usermind-release.txt

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: distelli
-version: "0.1.3-alpha3"
+version: "0.1.3-alpha4"
 description: Executes a distelli CLI command
 keywords:
   - distelli


### PR DESCRIPTION
Data Store builds and deploys two artifacts, and the default configuration was colliding on the release text file. This adds support to the step to specify the release file per-step.

cc @jreichhold @theazureshadow 