### PR TITLE
Relaxed deploy rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # distelli
 
+[![wercker status](https://app.wercker.com/status/8a086b544ada1f28962252b35b4de1f3/m/master "wercker status")](https://app.wercker.com/project/bykey/8a086b544ada1f28962252b35b4de1f3)
+
 Downloads the [Distelli CLI](https://www.distelli.com/docs/distelli-cli-reference) and runs a command.
+
+# Best practices
+
+This step allows a choice on the spectrum of flexibility and guard rails,
+provided by the `branches` configuration key. If this key is set, then the
+distelli step will be skipped. This allows a project to define a set of
+branches from which deploys should be allowed.
+
+Setting this value via an environment variable in Wercker allows for maximum
+flexibility. With the set-up, different deploy targets can be allow to deploy
+from different branches, or the set of branches can be temporarily changed
+with out requiring an update to the wercker.yml in source control. See the
+example below for an illustration.
 
 ## Options.
 
@@ -13,7 +28,9 @@ Downloads the [Distelli CLI](https://www.distelli.com/docs/distelli-cli-referenc
 ### optional
 
 * `branches` - a whilelist of branches to allow commands on. If unset, all branches are allowed.
-* `manifest` - the distelli manifest file. Required for `push` command.
+* `manifest` - the distelli manifest file. Required for `push` and `deploy` commands.
+* `releaseFilename` - a file name to track Distelli release id between `push` and `deploy` commands.
+* `wait` - (do not) wait for a distelli deploy to finish before proceeding. Only supported for the `deploy` command.
 
 # Example
 
@@ -24,6 +41,7 @@ This form is necessary to locate the pushed bundle for later deployment.
 build:
   steps:
     - distelli:
+        branches: ${ALLOWED_BRANCHES}
         accessKey: ${DISTELLI_TOKEN}
         secretKey: ${DISTELLI_SECRET}
         command: push

--- a/run.py
+++ b/run.py
@@ -35,7 +35,7 @@ def fail(text):
 def check_branches():
     branches = os.getenv("WERCKER_DISTELLI_BRANCHES")
 
-    if branches is None:
+    if not branches:
         return
 
     for branch in branches.split(","):

--- a/run.py
+++ b/run.py
@@ -185,7 +185,7 @@ def deploy(description):
     if release_id:
         args.extend(["-r", release_id])
 
-    wait = os.getenv("WERCKER_DISTELLI_WAIT")
+    wait = os.getenv("WERCKER_DISTELLI_WAIT").lower() != "false"
     if not wait:
         args.extend(["-q"])
 

--- a/run.py
+++ b/run.py
@@ -105,8 +105,9 @@ def load_release_id():
     release_id = os.getenv("WERCKER_DISTELLI_RELEASE")
 
     if not release_id:
-        with open(release_filename, "r") as release_file:
-            release_id = release_file.readline()
+        if os.path.exists(release_filename):
+            with open(release_filename, "r") as release_file:
+                release_id = release_file.readline()
 
     return release_id
 
@@ -121,7 +122,10 @@ def invoke(cmd, capture=False):
 
     # Distelli 1.88 assumes manifest is in CWD
     old_cwd = os.getcwd()
-    os.chdir(dirname)
+
+    # If dirname is blank, don't try to CD
+    if dirname:
+        os.chdir(dirname)
 
     # Wercker checks us out to a commit, not a branch name (sensible, since the
     # branch may have moved on). Distelli doesn't handle this well. We won't have
@@ -173,10 +177,13 @@ def deploy(description):
     else:
         fail("Either environment or host must be set")
 
-    release_id = load_release_id()
     (dirname, basename) = check_manifest()
 
-    args.extend(["-y", "-f", basename, "-r", release_id, "-m", description])
+    args.extend(["-y", "-f", basename, "-m", description])
+
+    release_id = load_release_id()
+    if release_id:
+        args.extend(["-r", release_id])
 
     cmd = "deploy %s" % " ".join(args)
     info(cmd)

--- a/run.py
+++ b/run.py
@@ -185,6 +185,10 @@ def deploy(description):
     if release_id:
         args.extend(["-r", release_id])
 
+    wait = os.getenv("WERCKER_DISTELLI_WAIT")
+    if not wait:
+        args.extend(["-q"])
+
     cmd = "deploy %s" % " ".join(args)
     info(cmd)
     output = invoke(cmd, capture=True)

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: distelli
-version: "0.1.4-alpha3"
+version: "0.1.4"
 description: Executes a distelli CLI command
 keywords:
   - distelli

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: distelli
-version: "0.1.4-alpha2"
+version: "0.1.4-alpha3"
 description: Executes a distelli CLI command
 keywords:
   - distelli
@@ -26,3 +26,7 @@ properties:
     type: string
     required: false
     default: usermind-release.txt
+  wait:
+    type: boolean
+    required: false
+    default: true

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: distelli
-version: "0.1.4-alpha1"
+version: "0.1.4-alpha2"
 description: Executes a distelli CLI command
 keywords:
   - distelli
@@ -13,7 +13,7 @@ properties:
   branches:
     type: array
     required: false
-    default: ['master']
+    default: []
   command:
     type: string
     required: true

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: distelli
-version: "0.1.3"
+version: "0.1.4-alpha1"
 description: Executes a distelli CLI command
 keywords:
   - distelli


### PR DESCRIPTION
When converting the rules-system project to use the new distelli step, I realized a number of the restrictions it enforced were a bit silly. This change corrects that.

* The `deploy` command can now be used without a prior `push` command. If the release file is absent, the command will push a bundle and depoy it immediately.
* Branch filtering is optional. Wercker does this perfectly well already.
* The `wait` flag was added so that wercker can be told not to wait for distelli to finish updating the hosts; the rules-system deploys time out without this.

cc @theazureshadow @jreichhold 
fyi @oflorescu 