### PR TITLE
Fix CSV parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ build:
 
 # Changelog
 
+## 0.2.4
+ - fixing csv parsing
+
 ## 0.2.3
  - error handling
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/csv"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -120,8 +121,17 @@ func locateReleaseID(buildURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	reader := csv.NewReader(output)
-	for row, err := reader.Read(); err != nil; {
+	for {
+		row, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+
 		description := row[3]
 		if strings.Contains(description, buildURL) {
 			releaseID = row[1]

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: distelli
-version: "0.2.3"
+version: "0.2.4"
 description: Executes a distelli CLI command
 keywords:
   - distelli


### PR DESCRIPTION
CSV parsing was broken, causing successful distelli pushes to not be able to find the build version.

Merging TBR.